### PR TITLE
60 event user data object enhancement

### DIFF
--- a/src/pages/events/[eventId]/edit.js
+++ b/src/pages/events/[eventId]/edit.js
@@ -96,7 +96,6 @@ function EditEvent({ event, organizer }) {
             if (user) {
                 // User is signed in
                 setUserMail(user.email);
-                console.log(user.email);
             } else {
                 // User is signed out
                 setUserMail(null); // Reset to null when signed out

--- a/src/pages/events/[eventId]/index.js
+++ b/src/pages/events/[eventId]/index.js
@@ -48,7 +48,7 @@ const EventsPage = ({ event, organizer, notFound }) => {
 
         const organizerData = organizerDoc.data();
         const updatedEventsCreated = organizerData.eventsCreated.filter(
-            (eventInfo) => eventInfo.uid !== event.eventId
+            (eventInfo) => eventInfo.eventId !== event.eventId
         );
 
         await updateDoc(organizerDocRef, {
@@ -115,7 +115,6 @@ const EventsPage = ({ event, organizer, notFound }) => {
 
         const eventInfo = {
             eventId: event.eventId,
-            title: docData.title,
         };
 
         // Update the user document to include the joined event

--- a/src/pages/events/create/index.js
+++ b/src/pages/events/create/index.js
@@ -52,13 +52,12 @@ const EventCreationPage = () => {
         const userId = auth?.currentUser?.uid;
         const userDocRef = doc(db, "users", userId);
 
-        const eventDoc = await getDoc(doc(db, "events", eventId));
-
-        const eventObject = eventDoc.data();
-        const eventInfo = { ...eventObject, uid: eventId };
+        const eventData = {
+            eventId: eventId,
+        };
 
         await updateDoc(userDocRef, {
-            eventsCreated: arrayUnion(eventInfo),
+            eventsCreated: arrayUnion(eventData),
         });
     };
     const addAndGoToEvent = async () => {
@@ -86,7 +85,6 @@ const EventCreationPage = () => {
             ...prevInput,
             [id]: value,
         }));
-        console.log(input.location, input.type);
     };
 
     const arrEventType = [


### PR DESCRIPTION
in this PR i made it sending less data to the users collection in firestore as keeping all event data in the events collection it self 

- if a user joins an event, they just get the eventId in the firestore
- if a user creates an event, they just get the eventId in firestore

# Related issue

- Resolve #60