### PR TITLE
style(signup): fix the overlapping of the signup page on some devices

### DIFF
--- a/src/pages/signup/index.js
+++ b/src/pages/signup/index.js
@@ -249,7 +249,7 @@ const SignUpPage = () => {
     };
 
     return (
-        <div className='flex justify-center items-center h-screen '>
+        <div className='flex justify-center items-center min-h-screen '>
             <div className='flex flex-col items-center sm:flex-row sm:w-1/ h-fit'>
                 <div className='mr-10'>
                     <img


### PR DESCRIPTION
1. fix the overlapping of the signup page
![image](https://github.com/202306-NEA-DZ-FEW/Pebble-work/assets/137835769/47618aeb-e28f-46e9-9150-b56d1ce879f7)


# Related issue

- Resolve #136